### PR TITLE
Add an API to read an put an object on the realtime repl queue

### DIFF
--- a/src/riak_repl_rtenqueue.erl
+++ b/src/riak_repl_rtenqueue.erl
@@ -1,0 +1,124 @@
+%% --------------------------------------------------------------------------
+%%
+%% riak_repl_rtenqueue - common client code for PB/HTTP to use for rtq enqueue
+%%
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% --------------------------------------------------------------------------
+
+%% @doc riak local client style command for putting Riak bucket/key
+%% onto the realtime repl queue
+%%
+
+-module(riak_repl_rtenqueue).
+
+-export([rt_enqueue/4]).
+
+%% @doc Users of Riak sometimes want Riak to realtime replicate an
+%% object on demand (dropped messages, external divergence detection
+%% etc) This function gets the object stored under `Bucket' `Key',
+%% with the get options from `Options' and calls the postcommit
+%% function(s) defined for realtime IF realtime is enabled for
+%% `Bucket'. Returns `ok' if all went well, or `{error, Reason}' is
+%% there was a failure. Riak seems to support "hybrid" configurations
+%% with the possibility that two types of realtime queue are in use,
+%% therefore error may obscure partial success.
+-spec rt_enqueue(Bucket, Key, Options, Client) ->
+                        ok | Error
+                            when
+      Bucket::riak_object:bucket(),
+      Key::riak_object:key(),
+      Options::riak_kv_get_fsm:options(),
+      Client::riak_client:client(),
+      Error::{error, Reason},
+      Reason::term().
+rt_enqueue(Bucket, Key, Options, Client) ->
+    GetRes = Client:get(Bucket, Key, Options),
+    case GetRes of
+        {ok, Object} ->
+            rt_enqueue_object(Object);
+        GetErr ->
+            GetErr
+    end.
+
+%% @private used by rt_equeue, once the object has been got.
+-spec rt_enqueue_object(riak_object:object()) ->
+                               ok | {error, ErrReason::term()}.
+rt_enqueue_object(Object) ->
+    BucketProps = get_bucket_props(Object),
+    %% If repl is a thing, then get the postcommit hook(s) from the
+    %% util (not the props) as the props does not name hooks, and may
+    %% have many we don't care about. See riak_repl:fixup/2
+    RTEnabled = app_helper:get_env(riak_repl, rtenabled, false),
+
+    case proplists:get_value(repl, BucketProps) of
+        Val when (Val==true orelse Val==realtime orelse Val==both),
+                 RTEnabled == true  ->
+            Hooks = riak_repl_util:get_hooks_for_modes(),
+            run_rt_hooks(Object, Hooks, []);
+        _ ->
+            {error, realtime_not_enabled}
+    end.
+
+
+-spec run_rt_hooks(riak_object:riak_object(), Hooks::list(), ResAcc::list()) ->
+                          ok | {error, Err::term()}.
+run_rt_hooks(_Object, _Hooks=[], Acc) ->
+    lists:foldl(fun rt_repl_results/2, ok, Acc);
+run_rt_hooks(Object, [{struct, Hook} | Hooks], Acc) ->
+    %% Bit jankey as it duplicates code in riak_kv_fsm postcommit
+    ModBin = proplists:get_value(<<"mod">>, Hook),
+    FunBin = proplists:get_value(<<"fun">>, Hook),
+
+    Res =
+        try
+            Mod = binary_to_atom(ModBin, utf8),
+            Fun = binary_to_atom(FunBin, utf8),
+            Mod:Fun(Object)
+        catch
+             Class:Exception ->
+                {error, {Hook, Class, Exception}}
+        end,
+    run_rt_hooks(Object, Hooks, [Res | Acc]).
+
+-spec rt_repl_results(Res, ResAcc) -> ResAcc when
+      Res :: ok | Err,
+      Err :: any(),
+      ResAcc:: ok | {error, list(Err)}.
+rt_repl_results(_Res=ok, _ResAcc=ok) ->
+    ok;
+rt_repl_results(ErrRes, _ResAcc=ok) ->
+    {error, [ErrRes]};
+rt_repl_results(ErrRes, {error, Errors}) ->
+    {error, [ErrRes | Errors]}.
+
+%% @doc get the properties for a riak_kv_object's bucket. This code
+%% appears in a few places, and I was about to cut and paste it to yet
+%% another, and decided to give it home.
+-spec get_bucket_props(riak_object:riak_object()) -> list({atom(), any()}).
+get_bucket_props(RObj) ->
+    Bucket = riak_object:bucket(RObj),
+    {ok, DefaultProps} = application:get_env(riak_core,
+                                             default_bucket_props),
+    BucketProps = riak_core_bucket:get_bucket(Bucket),
+    %% typed buckets never fall back to defaults
+    case is_tuple(Bucket) of
+        false ->
+            lists:keymerge(1, lists:keysort(1, BucketProps),
+                           lists:keysort(1, DefaultProps));
+        true ->
+            BucketProps
+    end.

--- a/src/riak_repl_web.erl
+++ b/src/riak_repl_web.erl
@@ -23,7 +23,17 @@
 -export([dispatch_table/0]).
 
 dispatch_table() ->
+    Props = props(),
     [
-     {["riak-repl", "stats"],  riak_repl_wm_stats, []}
+     {["riak-repl", "stats"],  riak_repl_wm_stats, []},
+
+     {["rtq", bucket_type, bucket, key],
+      riak_repl_wm_rtenqueue, Props},
+
+     {["rtq", bucket, key],
+      riak_repl_wm_rtenqueue, Props}
      ].
+
+props() ->
+    [{riak, local}, {bucket_type, <<"default">>}].
 

--- a/src/riak_repl_wm_rtenqueue.erl
+++ b/src/riak_repl_wm_rtenqueue.erl
@@ -1,0 +1,316 @@
+%% --------------------------------------------------------------------------
+%%
+%% riak_repl_wm_rtenqueue - Webmachine resource for posting a bucket/key to the
+%%                       realtime repl queue.
+%%
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% --------------------------------------------------------------------------
+
+%% @doc Resource for putting Riak bucket/key onto the realtime repl queue, over HTTP.
+%%
+%% Available operations:
+%%
+%% POST /rtq/Type/Bucket/Key
+%%  POST /rtq/Bucket/Key
+%%   POST a particular bucket/key to the realtime repl queue
+
+-module(riak_repl_wm_rtenqueue).
+
+%% webmachine resource exports
+-export([
+         init/1,
+         is_authorized/2,
+         forbidden/2,
+         allowed_methods/2,
+         resource_exists/2,
+         malformed_request/2,
+         service_available/2,
+         process_post/2
+        ]).
+
+-record(ctx, {
+              client,     %% :: riak_client()             %% the store client
+              riak,       %% local | {node(), atom()}     %% params for riak client
+              bucket_type :: binary(),                    %% bucket type (from uri)
+              bucket      :: binary(),                    %% Bucket name (from uri)
+              key         :: binary(),                    %% Key (from uri)
+              r,            %% integer() - r-value for reads
+              pr,           %% integer() - number of primary nodes required in preflist on read
+              basic_quorum, %% boolean() - whether to use basic_quorum
+              notfound_ok,  %% boolean() - whether to treat notfounds as successes
+              prefix,       %% string() - prefix for resource uris
+              doc,          %% {ok, riak_object()}|{error, term()} - the object found
+              timeout,      %% integer() - passed-in timeout value in ms
+              security    :: riak_core_security:context() %% security context
+             }).
+
+-type context() :: #ctx{}.
+
+-include_lib("webmachine/include/webmachine.hrl").
+-include_lib("riak_kv/src/riak_kv_wm_raw.hrl").
+
+-spec init(proplists:proplist()) -> {ok, context()}.
+%% @doc Initialize this resource.  This function extracts the
+%%      'riak' properties from the dispatch args.
+init(Props) ->
+    {ok, #ctx{
+            riak=proplists:get_value(riak, Props),
+            bucket_type=proplists:get_value(bucket_type, Props)}}.
+
+is_authorized(ReqData, Ctx) ->
+    case riak_api_web_security:is_authorized(ReqData) of
+        false ->
+            {"Basic realm=\"Riak\"", ReqData, Ctx};
+        {true, SecContext} ->
+            {true, ReqData, Ctx#ctx{security=SecContext}};
+        insecure ->
+            %% XXX 301 may be more appropriate here, but since the http and
+            %% https port are different and configurable, it is hard to figure
+            %% out the redirect URL to serve.
+            {{halt, 426}, wrq:append_to_resp_body(<<"Security is enabled and "
+                    "Riak does not accept credentials over HTTP. Try HTTPS "
+                    "instead.">>, ReqData), Ctx}
+    end.
+
+-spec service_available(#wm_reqdata{}, context()) ->
+    {boolean(), #wm_reqdata{}, context()}.
+%% @doc Determine whether or not a connection to Riak
+%%      can be established. Also, extract query params.
+service_available(RD, Ctx0=#ctx{riak=RiakProps}) ->
+    Ctx = riak_kv_wm_utils:ensure_bucket_type(RD, Ctx0, #ctx.bucket_type),
+    case riak_kv_wm_utils:get_riak_client(RiakProps, riak_kv_wm_utils:get_client_id(RD)) of
+        {ok, C} ->
+            {true,
+             RD,
+             Ctx#ctx{
+               client=C,
+               bucket=case wrq:path_info(bucket, RD) of
+                         undefined -> undefined;
+                         B -> list_to_binary(riak_kv_wm_utils:maybe_decode_uri(RD, B))
+                      end,
+               key=case wrq:path_info(key, RD) of
+                       undefined -> undefined;
+                       K -> list_to_binary(riak_kv_wm_utils:maybe_decode_uri(RD, K))
+                   end
+              }};
+        Error ->
+            {false,
+             wrq:set_resp_body(
+               io_lib:format("Unable to connect to Riak: ~p~n", [Error]),
+               wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+             Ctx}
+    end.
+
+forbidden(RD, Ctx = #ctx{security=undefined}) ->
+    {riak_kv_wm_utils:is_forbidden(RD), RD, Ctx};
+forbidden(RD, Ctx) ->
+    case riak_kv_wm_utils:is_forbidden(RD) of
+        true ->
+            {true, RD, Ctx};
+        false ->
+            Res = riak_core_security:check_permission({"riak_repl.rtenqueue",
+                                                       {Ctx#ctx.bucket_type, Ctx#ctx.bucket}},
+                                                      Ctx#ctx.security),
+            case Res of
+                {false, Error, _} ->
+                    RD1 = wrq:set_resp_header("Content-Type", "text/plain", RD),
+                    {true, wrq:append_to_resp_body(
+                             unicode:characters_to_binary(
+                               Error, utf8, utf8), RD1), Ctx};
+                {true, _} ->
+                    {false, RD, Ctx}
+            end
+    end.
+
+-spec allowed_methods(#wm_reqdata{}, context()) ->
+    {[atom()], #wm_reqdata{}, context()}.
+%% @doc Get the list of methods this resource supports.
+%%      Properties allows, POST.
+allowed_methods(RD, Ctx) ->
+    {['POST'], RD, Ctx}.
+
+resource_exists(RD, #ctx{bucket_type=BType}=Ctx) ->
+    {riak_kv_wm_utils:bucket_type_exists(BType), RD, Ctx}.
+
+-spec malformed_request(#wm_reqdata{}, context()) ->
+    {boolean(), #wm_reqdata{}, context()}.
+malformed_request(RD, Ctx) ->
+    case malformed_timeout_param(RD, Ctx) of
+        {false, RD2, Ctx2} ->
+            malformed_rw_params(RD2, Ctx2);
+        Mal ->
+            Mal
+    end.
+
+-spec process_post(#wm_reqdata{}, context()) ->
+    {true, #wm_reqdata{}, context()}.
+%% @doc do the deed
+process_post(RD, Ctx) ->
+    #ctx{client=C, bucket_type=T, bucket=B, key=K,
+        basic_quorum=Quorum, notfound_ok=NotFoundOK, r=R, pr=PR} = Ctx,
+            Options = [
+                        {basic_quorum, Quorum},
+                        {notfound_ok, NotFoundOK},
+                        {r, R},
+                        {pr, PR}
+                       ],
+    Res = riak_repl_rtenqueue:rt_enqueue(riak_kv_wm_utils:maybe_bucket_type(T,B), K, Options, C),
+    case Res of
+        ok ->
+            {true, RD, Ctx};
+        {error, Reason} ->
+            handle_common_error(Reason, RD, Ctx)
+    end.
+
+-spec malformed_timeout_param(#wm_reqdata{}, context()) ->
+    {boolean(), #wm_reqdata{}, context()}.
+%% @doc Check that the timeout parameter is are a
+%%      string-encoded integer.  Store the integer value
+%%      in context() if so.
+malformed_timeout_param(RD, Ctx) ->
+    case wrq:get_qs_value("timeout", none, RD) of
+        none ->
+            {false, RD, Ctx};
+        TimeoutStr ->
+            try
+                Timeout = list_to_integer(TimeoutStr),
+                {false, RD, Ctx#ctx{timeout=Timeout}}
+            catch
+                _:_ ->
+                    {true,
+                     wrq:append_to_resp_body(io_lib:format("Bad timeout "
+                                                           "value ~p~n",
+                                                           [TimeoutStr]),
+                                             wrq:set_resp_header(?HEAD_CTYPE,
+                                                                 "text/plain", RD)),
+                     Ctx}
+            end
+    end.
+
+-spec malformed_rw_params(#wm_reqdata{}, context()) ->
+    {boolean(), #wm_reqdata{}, context()}.
+%% @doc Check that r, w, dw, and rw query parameters are
+%%      string-encoded integers.  Store the integer values
+%%      in context() if so.
+malformed_rw_params(RD, Ctx) ->
+    Res =
+        lists:foldl(fun malformed_rw_param/2,
+                    {false, RD, Ctx},
+                    [{#ctx.r, "r", "default"},
+                     {#ctx.pr, "pr", "default"}]),
+    lists:foldl(fun malformed_boolean_param/2,
+                Res,
+                [{#ctx.basic_quorum, "basic_quorum", "default"},
+                 {#ctx.notfound_ok, "notfound_ok", "default"}]).
+
+-spec malformed_rw_param({Idx::integer(), Name::string(), Default::string()},
+                         {boolean(), #wm_reqdata{}, context()}) ->
+    {boolean(), #wm_reqdata{}, context()}.
+%% @doc Check that a specific r, or pr query param is a string-encoded
+%% integer.  Store its result in context() if it is, or print an error
+%% message in #wm_reqdata{} if it is not.
+malformed_rw_param({Idx, Name, Default}, {Result, RD, Ctx}) ->
+    case catch normalize_rw_param(wrq:get_qs_value(Name, Default, RD)) of
+        P when (is_atom(P) orelse is_integer(P)) ->
+            {Result, RD, setelement(Idx, Ctx, P)};
+        _ ->
+            {true,
+             wrq:append_to_resp_body(
+               io_lib:format("~s query parameter must be an integer or "
+                   "one of the following words: 'one', 'quorum' or 'all'~n",
+                             [Name]),
+               wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+             Ctx}
+    end.
+
+-spec malformed_boolean_param({Idx::integer(), Name::string(), Default::string()},
+                              {boolean(), #wm_reqdata{}, context()}) ->
+    {boolean(), #wm_reqdata{}, context()}.
+%% @doc Check that a specific query param is a
+%%      string-encoded boolean.  Store its result in context() if it
+%%      is, or print an error message in #wm_reqdata{} if it is not.
+malformed_boolean_param({Idx, Name, Default}, {Result, RD, Ctx}) ->
+    case string:to_lower(wrq:get_qs_value(Name, Default, RD)) of
+        "true" ->
+            {Result, RD, setelement(Idx, Ctx, true)};
+        "false" ->
+            {Result, RD, setelement(Idx, Ctx, false)};
+        "default" ->
+            {Result, RD, setelement(Idx, Ctx, default)};
+        _ ->
+            {true,
+            wrq:append_to_resp_body(
+              io_lib:format("~s query parameter must be true or false~n",
+                            [Name]),
+              wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+             Ctx}
+    end.
+
+normalize_rw_param("default") -> default;
+normalize_rw_param("one") -> one;
+normalize_rw_param("quorum") -> quorum;
+normalize_rw_param("all") -> all;
+normalize_rw_param(V) -> list_to_integer(V).
+
+handle_common_error(Reason, RD, Ctx) ->
+    case {error, Reason} of
+        {error, timeout} ->
+            {{halt, 503},
+                wrq:set_resp_header("Content-Type", "text/plain",
+                    wrq:append_to_response_body(
+                        io_lib:format("request timed out~n",[]),
+                        RD)),
+                Ctx};
+        {error, notfound} ->
+            {{halt, 404},
+                wrq:set_resp_header("Content-Type", "text/plain",
+                    wrq:append_to_response_body(
+                        io_lib:format("not found~n",[]),
+                        RD)),
+                Ctx};
+        {error, bucket_type_unknown} ->
+            {{halt, 404},
+             wrq:set_resp_body(
+               io_lib:format("Unknown bucket type: ~s", [Ctx#ctx.bucket_type]),
+               wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+             Ctx};
+        {error, {r_val_unsatisfied, Requested, Returned}} ->
+            {{halt, 503},
+                wrq:set_resp_header("Content-Type", "text/plain",
+                    wrq:append_to_response_body(
+                        io_lib:format("R-value unsatisfied: ~p/~p~n",
+                            [Returned, Requested]),
+                        RD)),
+                Ctx};
+        {error, {pr_val_unsatisfied, Requested, Returned}} ->
+            {{halt, 503},
+                wrq:set_resp_header("Content-Type", "text/plain",
+                    wrq:append_to_response_body(
+                        io_lib:format("PR-value unsatisfied: ~p/~p~n",
+                            [Returned, Requested]),
+                        RD)),
+                Ctx};
+        {error, failed} ->
+            {{halt, 412}, RD, Ctx};
+        {error, Err} ->
+            {{halt, 500},
+                wrq:set_resp_header("Content-Type", "text/plain",
+                    wrq:append_to_response_body(
+                        io_lib:format("Error:~n~p~n",[Err]),
+                        RD)),
+                Ctx}
+    end.


### PR DESCRIPTION
The realtime repl queue can drop objects. It may be possible also to
detect inter-cluster divergence by external mechanisms (for example
writing last-modified as an index and comparing query results between
clusters.) An in progress feature allows rapid cluster contents
divergence checking with tic-tac-tree based AAE. Any of these use
cases needs a way to prompt replication of an object. This feature
provides that.

The API accepts a bucket/key pair, and the many of the same options as
a GET. Riak then fetches the object, and enqueues it on the repl
queue. Returning ok or an error.

NOTE: this work was originally merged to riak_kv, but that was the
wrong place for it. This is re-working and move of the code in
https://github.com/martinsumner/riak_kv/pull/6